### PR TITLE
Add lookup key 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tracing = { version = "0.1", default-features = true }
 uuid = { version = "1.10.0", features = ["v4"] }
 
 [dev-dependencies]
+anyhow = "1.0"
 clap = { version = "4.5", features = [
     "std",
     "derive",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
-    command: postgres -c wal_level=logical
+    command: postgres 
+      -c wal_level=logical 
+      -c max_wal_senders=32
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 3s

--- a/src/clients/postgres.rs
+++ b/src/clients/postgres.rs
@@ -256,7 +256,7 @@ impl ReplicationClient {
         Ok(column_schemas)
     }
 
-    async fn query_lookup_key(
+    async fn fetch_lookup_key(
         &self,
         table_id: TableId,
         published_column_names: HashSet<String>,
@@ -369,7 +369,7 @@ impl ReplicationClient {
     ) -> Result<LookupKey, ReplicationClientError> {
         let column_names: HashSet<String> =
             column_schemas.iter().map(|cs| cs.name.clone()).collect();
-        if let Some(unique_index_key) = self.query_lookup_key(table_id, column_names).await? {
+        if let Some(unique_index_key) = self.fetch_lookup_key(table_id, column_names).await? {
             return Ok(unique_index_key);
         }
 

--- a/src/clients/postgres.rs
+++ b/src/clients/postgres.rs
@@ -339,13 +339,6 @@ impl ReplicationClient {
             let table_schema = self
                 .get_table_schema(table_name.clone(), publication)
                 .await?;
-            if !table_schema.has_safe_lookup_key() {
-                warn!(
-                    "table {} with id {} will not be copied because it has no primary key",
-                    table_schema.table_name, table_schema.table_id
-                );
-                continue;
-            }
             table_schemas.insert(table_schema.table_id, table_schema);
         }
 

--- a/src/clients/postgres.rs
+++ b/src/clients/postgres.rs
@@ -220,6 +220,7 @@ impl ReplicationClient {
                     .parse()
                     .map_err(|_| ReplicationClientError::OidColumnNotU32)?;
 
+                //TODO: For now we assume all types are simple, fix it later
                 let typ = Type::from_oid(type_oid).unwrap_or(Type::new(
                     format!("unnamed(oid: {type_oid})"),
                     type_oid,
@@ -300,9 +301,9 @@ impl ReplicationClient {
         Ok(None)
     }
 
-    /// A valid index for replica identity
+    /// Finds a valid index for lookup key
     /// must be unique, not partial, not deferrable, and include only columns marked NOT NULL.
-    /// As per [https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY]
+    /// Follows same definition as PG replica identity [https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY]
     async fn fetch_index_rows(
         &self,
         table_id: TableId,

--- a/src/clients/postgres.rs
+++ b/src/clients/postgres.rs
@@ -275,7 +275,7 @@ impl ReplicationClient {
             let table_schema = self
                 .get_table_schema(table_name.clone(), publication)
                 .await?;
-            if !table_schema.has_primary_keys() {
+            if !table_schema.has_safe_lookup_key() {
                 warn!(
                     "table {} with id {} will not be copied because it has no primary key",
                     table_schema.table_name, table_schema.table_id

--- a/src/table.rs
+++ b/src/table.rs
@@ -34,6 +34,12 @@ pub struct ColumnSchema {
     pub primary: bool,
 }
 
+#[derive(Debug, Clone)]
+pub enum LookupKey {
+    Key { name: String, columns: Vec<String> },
+    FullRow,
+}
+
 pub type TableId = u32;
 
 #[derive(Debug, Clone)]
@@ -41,6 +47,7 @@ pub struct TableSchema {
     pub table_name: TableName,
     pub table_id: TableId,
     pub column_schemas: Vec<ColumnSchema>,
+    pub lookup_key: LookupKey,
 }
 
 impl TableSchema {

--- a/src/table.rs
+++ b/src/table.rs
@@ -31,7 +31,6 @@ pub struct ColumnSchema {
     pub typ: Type,
     pub modifier: TypeModifier,
     pub nullable: bool,
-    pub primary: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -59,8 +58,5 @@ impl TableSchema {
             }
             _ => true,
         }
-    }
-}
-
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -51,7 +51,16 @@ pub struct TableSchema {
 }
 
 impl TableSchema {
-    pub fn has_primary_keys(&self) -> bool {
-        self.column_schemas.iter().any(|cs| cs.primary)
+    pub fn has_safe_lookup_key(&self) -> bool {
+        match &self.lookup_key {
+            LookupKey::FullRow => {
+                // At least one published column must be NOT NULL
+                self.column_schemas.iter().any(|c| !c.nullable)
+            }
+            _ => true,
+        }
+    }
+}
+
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -49,14 +49,4 @@ pub struct TableSchema {
     pub lookup_key: LookupKey,
 }
 
-impl TableSchema {
-    pub fn has_safe_lookup_key(&self) -> bool {
-        match &self.lookup_key {
-            LookupKey::FullRow => {
-                // All columns must be non-nullable
-                self.column_schemas.iter().all(|col| col.nullable == false)
-            }
-            _ => true,
-        }
-    }
-}
+impl TableSchema {}

--- a/src/table.rs
+++ b/src/table.rs
@@ -54,8 +54,8 @@ impl TableSchema {
     pub fn has_safe_lookup_key(&self) -> bool {
         match &self.lookup_key {
             LookupKey::FullRow => {
-                // At least one published column must be NOT NULL
-                self.column_schemas.iter().any(|c| !c.nullable)
+                // All columns must be non-nullable
+                self.column_schemas.iter().all(|col| col.nullable == false)
             }
             _ => true,
         }

--- a/tests/clients/mod.rs
+++ b/tests/clients/mod.rs
@@ -1,0 +1,1 @@
+pub mod postgres;

--- a/tests/clients/mod.rs
+++ b/tests/clients/mod.rs
@@ -1,1 +1,101 @@
+use crate::common::{
+    POSTGRES_DBNAME, POSTGRES_HOST, POSTGRES_PASSWORD, POSTGRES_PORT, POSTGRES_USER,
+};
+use pg_replicate::clients::postgres::ReplicationClient;
+use pg_replicate::table::LookupKey;
 pub mod postgres;
+
+pub async fn create_replication_client() -> ReplicationClient {
+    ReplicationClient::connect_no_tls(
+        POSTGRES_HOST,
+        POSTGRES_PORT,
+        POSTGRES_DBNAME,
+        POSTGRES_USER,
+        Some(POSTGRES_PASSWORD.to_string()),
+    )
+    .await
+    .expect("Failed to connect to postgres")
+}
+
+/// Helper function to assert that a LookupKey is a Key type with the expected columns
+pub fn assert_is_key(lookup_key: &LookupKey, expected_columns: &[&str]) {
+    match lookup_key {
+        LookupKey::Key { name: _, columns } => {
+            let expected: Vec<String> = expected_columns.iter().map(|&s| s.to_string()).collect();
+            assert_eq!(
+                &expected, columns,
+                "Key columns don't match expected columns"
+            );
+        }
+        LookupKey::FullRow => panic!("Expected Key type but got FullRow"),
+    }
+}
+
+/// Helper function to assert that a LookupKey is FullRow
+pub fn assert_is_full_row(lookup_key: &LookupKey) {
+    match lookup_key {
+        LookupKey::Key { name, columns } => {
+            panic!("Expected FullRow but got Key({}, {:?})", name, columns)
+        }
+        LookupKey::FullRow => (),
+    }
+}
+
+pub async fn test_lookup_key_with_definition(
+    table_name: &str,
+    create_sql: &str,
+    expected_key: Option<Vec<&str>>,
+    publication: Option<&str>,
+) -> Result<(), anyhow::Error> {
+    use crate::common::postgres_utils::TestTable;
+    use pg_replicate::table::TableName;
+
+    let test_table = TestTable::new(table_name, create_sql).await;
+
+    if let Some(pub_name) = publication {
+        let _ = test_table
+            .client
+            .simple_query(&format!("DROP PUBLICATION IF EXISTS {}", pub_name))
+            .await;
+        let _ = test_table
+            .client
+            .simple_query(&format!(
+                "CREATE PUBLICATION {} FOR TABLE {}",
+                pub_name, table_name
+            ))
+            .await;
+    }
+
+    let replication_client = create_replication_client().await;
+
+    let table_name = TableName {
+        schema: "public".to_string(),
+        name: table_name.to_string(),
+    };
+
+    let table_id = replication_client
+        .get_table_id(&table_name)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("table ID not found!"))?;
+
+    let column_schemas = replication_client
+        .get_column_schemas(table_id, publication)
+        .await?;
+    let lookup_key = replication_client
+        .get_lookup_key(table_id, &column_schemas)
+        .await?;
+
+    match expected_key {
+        Some(columns) => assert_is_key(&lookup_key, &columns),
+        None => assert_is_full_row(&lookup_key),
+    }
+
+    if let Some(pub_name) = publication {
+        let _ = test_table
+            .client
+            .simple_query(&format!("DROP PUBLICATION IF EXISTS {}", pub_name))
+            .await;
+    }
+
+    Ok(())
+}

--- a/tests/clients/mod.rs
+++ b/tests/clients/mod.rs
@@ -17,7 +17,6 @@ pub async fn create_replication_client() -> ReplicationClient {
     .expect("Failed to connect to postgres")
 }
 
-/// Helper function to assert that a LookupKey is a Key type with the expected columns
 pub fn assert_is_key(lookup_key: &LookupKey, expected_columns: &[&str]) {
     match lookup_key {
         LookupKey::Key { name: _, columns } => {
@@ -31,7 +30,6 @@ pub fn assert_is_key(lookup_key: &LookupKey, expected_columns: &[&str]) {
     }
 }
 
-/// Helper function to assert that a LookupKey is FullRow
 pub fn assert_is_full_row(lookup_key: &LookupKey) {
     match lookup_key {
         LookupKey::Key { name, columns } => {

--- a/tests/clients/postgres.rs
+++ b/tests/clients/postgres.rs
@@ -1,0 +1,325 @@
+use super::{
+    assert_is_full_row, assert_is_key, create_replication_client, test_lookup_key_with_definition,
+};
+
+use crate::common::postgres_utils::TestTable;
+use pg_replicate::table::TableName;
+
+#[tokio::test]
+async fn test_lookup_key_with_primary_key() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_pk_table (
+            id INT PRIMARY KEY,
+            data TEXT
+        )
+    ";
+
+    test_lookup_key_with_definition("test_pk_table", create_sql, Some(vec!["id"]), None).await
+}
+
+#[tokio::test]
+async fn test_lookup_key_with_composite_primary_key() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_composite_pk_table (
+            id1 INT,
+            id2 TEXT,
+            data TEXT,
+            PRIMARY KEY (id1, id2)
+        )
+    ";
+
+    test_lookup_key_with_definition(
+        "test_composite_pk_table",
+        create_sql,
+        Some(vec!["id1", "id2"]),
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_with_unique_constraint() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_unique_constraint_table (
+            id INT,
+            email TEXT UNIQUE,
+            data TEXT
+        )
+    ";
+
+    test_lookup_key_with_definition(
+        "test_unique_constraint_table",
+        create_sql,
+        Some(vec!["email"]),
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_prefers_primary_key_over_unique() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_pk_and_unique_table (
+            id INT PRIMARY KEY,
+            email TEXT UNIQUE,
+            data TEXT
+        )
+    ";
+
+    test_lookup_key_with_definition(
+        "test_pk_and_unique_table",
+        create_sql,
+        Some(vec!["id"]),
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_ignores_nullable_unique_columns() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_nullable_unique_table (
+            id INT,
+            email TEXT NULL UNIQUE,
+            data TEXT
+        )
+    ";
+
+    test_lookup_key_with_definition(
+        "test_nullable_unique_table",
+        create_sql,
+        None, // Expect FullRow
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_ignores_partial_indexes() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_partial_index_table (
+            id INT,
+            email TEXT,
+            active BOOLEAN,
+            data TEXT
+        );
+        CREATE UNIQUE INDEX idx_partial_email ON test_partial_index_table (email) WHERE active = true;
+    ";
+
+    test_lookup_key_with_definition(
+        "test_partial_index_table",
+        create_sql,
+        None, // Expect FullRow
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_with_no_unique_constraints() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_no_unique_table (
+            id INT,
+            data TEXT
+        )
+    ";
+
+    test_lookup_key_with_definition(
+        "test_no_unique_table",
+        create_sql,
+        None, // Expect FullRow
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_with_multicolumn_unique_index() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_multicolumn_unique_index (
+            first_name TEXT,
+            last_name TEXT,
+            email TEXT,
+            data TEXT,
+            CONSTRAINT unique_name UNIQUE (first_name, last_name)
+        )
+    ";
+
+    test_lookup_key_with_definition(
+        "test_multicolumn_unique_index",
+        create_sql,
+        Some(vec!["first_name", "last_name"]),
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_respects_publication_columns() -> Result<(), anyhow::Error> {
+    let pub_name = "test_pub";
+    let table_name = "test_publication_columns";
+
+    let create_sql = format!(
+        "
+        CREATE TABLE {} (
+            id INT PRIMARY KEY,
+            email TEXT UNIQUE,
+            data TEXT
+        )
+        ",
+        table_name
+    );
+
+    // Create a test table instance
+    let test_table = TestTable::new(table_name, &create_sql).await;
+
+    // Create publication with column list
+    test_table
+        .client
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {}", pub_name))
+        .await
+        .unwrap();
+    test_table
+        .client
+        .simple_query(&format!(
+            "CREATE PUBLICATION {} FOR TABLE {} (email, data)",
+            pub_name, table_name
+        ))
+        .await
+        .unwrap();
+
+    let replication_client = create_replication_client().await;
+
+    let table_name = TableName {
+        schema: "public".to_string(),
+        name: table_name.to_string(),
+    };
+
+    let table_id = replication_client
+        .get_table_id(&table_name)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("table ID not found!"))?;
+
+    // Get columns with publication filtering
+    let column_schemas = replication_client
+        .get_column_schemas(table_id, Some(pub_name))
+        .await?;
+    let lookup_key = replication_client
+        .get_lookup_key(table_id, &column_schemas)
+        .await?;
+
+    // Should use email as the key since id is not in the publication
+    assert_is_key(&lookup_key, &["email"]);
+
+    // Clean up
+    test_table
+        .client
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {}", pub_name))
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lookup_key_with_multiple_unique_indexes() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_multiple_unique_indexes (
+            id INT,
+            username TEXT UNIQUE,
+            email TEXT UNIQUE,
+            data TEXT
+        )
+    ";
+
+    // Should choose the first unique index alphabetically after primary keys
+    test_lookup_key_with_definition(
+        "test_multiple_unique_indexes",
+        create_sql,
+        Some(vec!["email"]), // Postgres sorts indexes alphabetically
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_with_mixed_nullable_non_nullable_unique() -> Result<(), anyhow::Error> {
+    let create_sql = "
+        CREATE TABLE test_mixed_nullable (
+            id INT,
+            username TEXT NULL UNIQUE,
+            email TEXT NOT NULL UNIQUE,
+            data TEXT
+        )
+    ";
+
+    // Should choose the non-nullable unique index
+    test_lookup_key_with_definition("test_mixed_nullable", create_sql, Some(vec!["email"]), None)
+        .await
+}
+
+#[tokio::test]
+async fn test_lookup_key_with_no_columns_in_publication() -> Result<(), anyhow::Error> {
+    let pub_name = "test_pub_only_data";
+    let table_name = "test_publication_no_key_columns";
+
+    let create_sql = format!(
+        "
+        CREATE TABLE {} (
+            id INT PRIMARY KEY,
+            username TEXT UNIQUE,
+            data TEXT
+        )
+        ",
+        table_name
+    );
+
+    // Create a test table instance
+    let test_table = TestTable::new(table_name, &create_sql).await;
+
+    // Create a publication that only includes data column
+    test_table
+        .client
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {}", pub_name))
+        .await
+        .unwrap();
+    test_table
+        .client
+        .simple_query(&format!(
+            "CREATE PUBLICATION {} FOR TABLE {} (data)",
+            pub_name, table_name
+        ))
+        .await
+        .unwrap();
+
+    let replication_client = create_replication_client().await;
+
+    let table_name = TableName {
+        schema: "public".to_string(),
+        name: table_name.to_string(),
+    };
+
+    let table_id = replication_client
+        .get_table_id(&table_name)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("table ID not found!"))?;
+
+    let column_schemas = replication_client
+        .get_column_schemas(table_id, Some(pub_name))
+        .await?;
+    let lookup_key = replication_client
+        .get_lookup_key(table_id, &column_schemas)
+        .await?;
+
+    // Should fallback to full row since no key columns are in the publication
+    assert_is_full_row(&lookup_key);
+
+    // Clean up
+    test_table
+        .client
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {}", pub_name))
+        .await
+        .unwrap();
+
+    Ok(())
+}

--- a/tests/clients/postgres.rs
+++ b/tests/clients/postgres.rs
@@ -42,7 +42,7 @@ async fn test_lookup_key_with_unique_constraint() -> Result<(), anyhow::Error> {
     let create_sql = "
         CREATE TABLE test_unique_constraint_table (
             id INT,
-            email TEXT UNIQUE,
+            email TEXT NOT NULL UNIQUE,
             data TEXT
         )
     ";
@@ -137,8 +137,8 @@ async fn test_lookup_key_with_no_unique_constraints() -> Result<(), anyhow::Erro
 async fn test_lookup_key_with_multicolumn_unique_index() -> Result<(), anyhow::Error> {
     let create_sql = "
         CREATE TABLE test_multicolumn_unique_index (
-            first_name TEXT,
-            last_name TEXT,
+            first_name TEXT NOT NULL,
+            last_name TEXT NOT NULL,
             email TEXT,
             data TEXT,
             CONSTRAINT unique_name UNIQUE (first_name, last_name)
@@ -163,7 +163,7 @@ async fn test_lookup_key_respects_publication_columns() -> Result<(), anyhow::Er
         "
         CREATE TABLE {} (
             id INT PRIMARY KEY,
-            email TEXT UNIQUE,
+            email TEXT NOT NULL UNIQUE,
             data TEXT
         )
         ",
@@ -226,8 +226,8 @@ async fn test_lookup_key_with_multiple_unique_indexes() -> Result<(), anyhow::Er
     let create_sql = "
         CREATE TABLE test_multiple_unique_indexes (
             id INT,
-            username TEXT UNIQUE,
-            email TEXT UNIQUE,
+            username TEXT NOT NULL UNIQUE,
+            email TEXT NOT NULL UNIQUE,
             data TEXT
         )
     ";

--- a/tests/clients/postgres.rs
+++ b/tests/clients/postgres.rs
@@ -170,10 +170,8 @@ async fn test_lookup_key_respects_publication_columns() -> Result<(), anyhow::Er
         table_name
     );
 
-    // Create a test table instance
     let test_table = TestTable::new(table_name, &create_sql).await;
 
-    // Create publication with column list
     test_table
         .client
         .simple_query(&format!("DROP PUBLICATION IF EXISTS {}", pub_name))
@@ -274,7 +272,6 @@ async fn test_lookup_key_with_no_columns_in_publication() -> Result<(), anyhow::
         table_name
     );
 
-    // Create a test table instance
     let test_table = TestTable::new(table_name, &create_sql).await;
 
     // Create a publication that only includes data column

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,2 +1,1 @@
-pub mod postgres;
-
+pub mod postgres_utils;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,1 +1,7 @@
 pub mod postgres_utils;
+
+pub const POSTGRES_HOST: &str = "127.0.0.1";
+pub const POSTGRES_PORT: u16 = 5432;
+pub const POSTGRES_USER: &str = "postgres";
+pub const POSTGRES_PASSWORD: &str = "postgres";
+pub const POSTGRES_DBNAME: &str = "postgres";

--- a/tests/common/postgres_utils.rs
+++ b/tests/common/postgres_utils.rs
@@ -33,18 +33,15 @@ impl Drop for TestTable {
     fn drop(&mut self) {
         let table = self.table.clone();
 
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async move {
-                match create_postgres_client()
-                    .await
-                    .simple_query(&format!("DROP TABLE IF EXISTS {} CASCADE", table))
-                    .await
-                {
-                    Ok(_) => {}
-                    Err(e) => eprintln!("Error dropping table {}: {}", table, e),
-                }
-            });
+        tokio::task::spawn(async move {
+            match create_postgres_client()
+                .await
+                .simple_query(&format!("DROP TABLE IF EXISTS {} CASCADE", table))
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => eprintln!("Error dropping table {}: {}", table, e),
+            }
         });
     }
 }

--- a/tests/common/postgres_utils.rs
+++ b/tests/common/postgres_utils.rs
@@ -29,4 +29,3 @@ pub async fn wait_for_postgres_ready() {
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }
-

--- a/tests/common/postgres_utils.rs
+++ b/tests/common/postgres_utils.rs
@@ -1,11 +1,62 @@
+use super::{POSTGRES_DBNAME, POSTGRES_HOST, POSTGRES_PASSWORD, POSTGRES_PORT, POSTGRES_USER};
 use std::time::{Duration, Instant};
-use tokio_postgres::{connect, NoTls};
+use tokio_postgres::{connect, Client as PostgresClient, NoTls};
 
-pub fn postgres_connection_string() -> String {
-    "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres".to_string()
+/* A utility struct for managing test interactions with a PostgreSQL table.
+ # Fields
+ - `client`: A `PostgresClient` instance used to execute queries against the database.
+ - `table`: The name of the table being tested.
+
+ This struct is typically used in test cases to encapsulate the database client
+ and table name, simplifying the process of setting up and tearing down test data.
+*/
+pub struct TestTable {
+    pub client: PostgresClient,
+    pub table: String,
 }
 
-pub async fn wait_for_postgres_ready() {
+impl TestTable {
+    pub async fn new(table: &str, create_sql: &str) -> Self {
+        wait_for_postgres_ready().await;
+        let client = create_postgres_client().await;
+        let _ = drop_test_table(&client, table).await;
+        create_test_table(&client, create_sql).await.unwrap();
+
+        Self {
+            client,
+            table: table.to_string(),
+        }
+    }
+}
+
+impl Drop for TestTable {
+    fn drop(&mut self) {
+        let table = self.table.clone();
+
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async move {
+                match create_postgres_client()
+                    .await
+                    .simple_query(&format!("DROP TABLE IF EXISTS {} CASCADE", table))
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => eprintln!("Error dropping table {}: {}", table, e),
+                }
+            });
+        });
+    }
+}
+
+fn postgres_connection_string() -> String {
+    format!(
+        "host={} port={} user={} password={} dbname={}",
+        POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DBNAME
+    )
+}
+
+async fn wait_for_postgres_ready() {
     let conn_str = postgres_connection_string();
     let start = Instant::now();
 
@@ -28,4 +79,36 @@ pub async fn wait_for_postgres_ready() {
 
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
+}
+
+async fn create_postgres_client() -> PostgresClient {
+    let conn_str = postgres_connection_string();
+    let (client, connection) = connect(&conn_str, NoTls)
+        .await
+        .expect("Failed to connect to postgres");
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    client
+}
+
+async fn create_test_table(client: &PostgresClient, create_sql: &str) -> Result<(), String> {
+    client
+        .simple_query(create_sql)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+async fn drop_test_table(client: &PostgresClient, table_name: &str) -> Result<(), String> {
+    let drop_sql = format!("DROP TABLE IF EXISTS {} CASCADE", table_name);
+    client
+        .simple_query(&drop_sql)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,7 @@
+mod clients;
 mod common;
 
-use common::postgres::{postgres_connection_string, wait_for_postgres_ready};
+use common::postgres_utils::{postgres_connection_string, wait_for_postgres_ready};
 
 #[tokio::test]
 async fn test_basic_logical_replication() {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,27 +1,2 @@
 mod clients;
 mod common;
-
-use common::postgres_utils::{postgres_connection_string, wait_for_postgres_ready};
-
-#[tokio::test]
-async fn test_basic_logical_replication() {
-    wait_for_postgres_ready().await;
-
-    let conn_str = postgres_connection_string();
-
-    // Basic query to check connection
-    let (client, connection) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
-        .await
-        .unwrap();
-
-    // The connection object performs the actual communication with the database,
-    // so spawn it off to run on its own
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            eprintln!("connection error: {}", e);
-        }
-    });
-
-    let row = client.query_one("SELECT 1", &[]).await.unwrap();
-    assert_eq!(row.get::<_, i32>(0), 1);
-}


### PR DESCRIPTION
~~- Removes explicit check for primary keys in table schema.~~
~~- Adds some basic unit tests.~~

~~We want to use a "full" replica identity to avoid needing to query the table to find the original row. In this case we can drop the strict requirement for primary keys.~~

- Add support for fetching lookup key to be used in Moonlink
- Add integration testing ensuring that our lookup key respects the same constraints as [replica identity](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY)

====================

Further details:

Added an enum to `TableSchema` called `LookupKey`.
We should avoid the term “replica identity”, since this refers to the table-level setting that controls what is written to the WAL (e.g., DEFAULT, INDEX, FULL).

In contrast, `LookupKey` is a Moonlink-side concept: it defines how to locate the corresponding row in the moonlink subscriber when processing an UPDATE or DELETE.
Even when the table’s replica identity is set to FULL (which we always do to guarantee WAL emits full rows), we still need a way to identify rows on the subscriber side.

The `LookupKey` enum has two variants:
1) Key { name, columns }:
Represents either a primary key or a unique key.
	•	name: the name of the key
	•	columns: the ordered list of column names used by the key
2) FullRow:
Indicates no usable primary or unique key was found; Moonlink must fall back to matching against the entire row.
When searching for a usable unique key:

- We exclude any partial indices (WHERE clause present).
- We exclude any indices with nullable columns.
- We return the first match that satisfies these criteria.
- We exclude any deferrable indices
- We exclude any indices containing unpublished columns

