### PR TITLE
Add integration testing infrastructure 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo run -p pg_replicate --example stdout --features="stdout" -- --db-host loca
 
 In the above example, `pg_replicate` connects to a Postgres database named `postgres` running on `localhost:5432` with a username `postgres` and password `password`. The slot name `stdout_slot` will be created by `pg_replicate` automatically.
 
-Refer to the [examples](https://github.com/supabase/pg_replicate/tree/main/pg_replicate/examples) folder to run examples for sinks other than `stdout` (currently only `bigquery` and `duckdb` supported). A quick tip: to see all the command line options, run the example wihout any options specified, e.g. `cargo run --example bigquery` will print the detailed usage instructions for the `bigquery` sink.
+A quick tip: to see all the command line options, run the example wihout any options specified, e.g. `cargo run --example stdout` will print the detailed usage instructions for the `stdout` sink.
 
 ## Getting Started
 
@@ -104,34 +104,31 @@ To run the `pg_replicate` examples from the root of the repository, use the foll
 
 In the above command we ask cargo to run the examples from the `pg_replicate` crate in the workspace. We also enable the right features needed for the example. Usually the feature is named the same as the example. E.g.:
 
-`cargo run -p pg_replicate --example duckdb --features="duckdb"`
+`cargo run -p pg_replicate --example stdout --features="stdout"`
 
 If you are inside the `pg_replicate` folder inside the root, then you can omit the `-p pg_replicate` part from the command.
+
+## Testing
+
+To run the integration tests use
+
+```
+docker-compose up -d
+```
+
+to start the postgres server and then use
+
+```
+cargo test
+```
+
+as normal.
 
 ## Repository Structure
 
 The repository is a cargo workspace. Each of the individual sub-folders are crate in the workspace. A brief explanation of each crate is as follows:
 
-- `pg_replicate` - The main library crate containing the core logic.
-
-## Roadmap
-
-`pg_replicate` is still under heavy development so expect bugs and papercuts but overtime we plan to add the following sinks.
-
-- [x] Add BigQuery Sink
-- [x] Add DuckDb Sink
-- [x] Add MotherDuck Sink
-- [ ] Add Snowflake Sink
-- [ ] Add ClickHouse Sink
-- [ ] Many more to come...
-
-Note: DuckDb and MotherDuck sinks do no use the batched pipeline, hence they currently perform poorly. A batched pipeline version of these sinks is planned.
-
-See the [open issues](https://github.com/imor/pg_replicate/issues) for a full list of proposed features (and known issues).
-
-## License
-
-Distributed under the Apache-2.0 License. See `LICENSE` for more information.
+* `pg_replicate` - The main library crate containing the core logic.
 
 ## Design
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:15-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    command: postgres -c wal_level=logical
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 3s
+      timeout: 5s
+      retries: 5

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,2 @@
+pub mod postgres;
+

--- a/tests/common/postgres.rs
+++ b/tests/common/postgres.rs
@@ -1,0 +1,32 @@
+use std::time::{Duration, Instant};
+use tokio_postgres::{connect, NoTls};
+
+pub fn postgres_connection_string() -> String {
+    "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres".to_string()
+}
+
+pub async fn wait_for_postgres_ready() {
+    let conn_str = postgres_connection_string();
+    let start = Instant::now();
+
+    loop {
+        match connect(&conn_str, NoTls).await {
+            Ok((client, connection)) => {
+                tokio::spawn(async move {
+                    let _ = connection.await;
+                });
+                if client.query_one("SELECT 1", &[]).await.is_ok() {
+                    return;
+                }
+            }
+            Err(_) => {}
+        }
+
+        if start.elapsed() > Duration::from_secs(10) {
+            panic!("Timed out waiting for Postgres");
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,26 @@
+mod common;
+
+use common::postgres::{postgres_connection_string, wait_for_postgres_ready};
+
+#[tokio::test]
+async fn test_basic_logical_replication() {
+    wait_for_postgres_ready().await;
+
+    let conn_str = postgres_connection_string();
+
+    // Basic query to check connection
+    let (client, connection) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
+        .await
+        .unwrap();
+
+    // The connection object performs the actual communication with the database,
+    // so spawn it off to run on its own
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    let row = client.query_one("SELECT 1", &[]).await.unwrap();
+    assert_eq!(row.get::<_, i32>(0), 1);
+}


### PR DESCRIPTION
Adds basic integration testing infrastructure.

Adds a `docker-compose.yml` for the postgres dependency.
Adds a `postgres.rs` for common postgres utils that we can use during testing.
Also adds some instructions to the `README`. 